### PR TITLE
feat: add routes for update and delete in transaction

### DIFF
--- a/src/main/java/com/meicash/controller/TransactionController.java
+++ b/src/main/java/com/meicash/controller/TransactionController.java
@@ -36,4 +36,23 @@ public class TransactionController {
         Optional<ResponseTransactionDTO> transaction = transactionService.getTransactionById(transactionId);
         return transaction.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
     }
+
+    @PutMapping("/{transactionId}")
+    public ResponseEntity<ResponseTransactionDTO> updateTransaction(@PathVariable String transactionId, @RequestBody @Valid RequestTransactionDTO requestTransactionDTO) {
+        Optional<ResponseTransactionDTO> updatedTransaction = transactionService.updateTransaction(transactionId, requestTransactionDTO);
+        if (updatedTransaction.isPresent()) {
+            return ResponseEntity.ok(updatedTransaction.get());
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @DeleteMapping("/{transactionId}")
+    public ResponseEntity<Void> deleteTransaction(@PathVariable String transactionId) {
+        return transactionService.deleteTransaction(transactionId)
+                ? ResponseEntity.noContent().build()
+                : ResponseEntity.notFound().build();
+    }
+
+
 }

--- a/src/main/java/com/meicash/service/TransactionService.java
+++ b/src/main/java/com/meicash/service/TransactionService.java
@@ -51,4 +51,26 @@ public class TransactionService {
             return Optional.empty();
         }
     }
+
+    public Optional<ResponseTransactionDTO> updateTransaction(String transactionId, RequestTransactionDTO requestTransactionDTO) {
+        return transactionRepository.findById(transactionId).map(
+                transaction -> {
+                    transaction.setTimestamp(requestTransactionDTO.timestamp());
+                    transaction.setType(requestTransactionDTO.type());
+                    transaction.setCategory(requestTransactionDTO.category());
+                    transaction.setValue(requestTransactionDTO.value());
+                    transaction.setDescription(requestTransactionDTO.description());
+                    return transactionToResponseTransactionDTO(transactionRepository.save(transaction));
+                }
+        );
+    }
+
+    public boolean deleteTransaction(String transactionId) {
+        return transactionRepository.findById(transactionId)
+                .map(transaction -> {
+                    transactionRepository.delete(transaction);
+                    return true;
+                })
+                .orElse(false);
+    }
 }


### PR DESCRIPTION
## Proposta deste PR
- Assim como especificado na Issue #22, é preciso criar os endpoints de atualização e exclusão de transações para que a API forneça as rotas necessárias para a manipulação dos dados das transações

## Impactos deste PR
- Criar as rotas de `update` e `delete` para a entidade Transaction;

## Evidências de teste
### Atualizar Transação

![Captura de tela de 2024-06-04 14-53-06](https://github.com/JonasFortes12/MEICash-server/assets/65193369/39320f1d-a40c-45dc-87fd-cd451485b9ef)

### Deletar Transação

![Captura de tela de 2024-06-04 17-39-27](https://github.com/JonasFortes12/MEICash-server/assets/65193369/3698c488-8141-4e46-ae4b-c4a01721d60d)




