### PR TITLE
feat: add routes for update and delete category

### DIFF
--- a/src/main/java/com/meicash/controller/CategoryController.java
+++ b/src/main/java/com/meicash/controller/CategoryController.java
@@ -4,6 +4,7 @@ import com.meicash.domain.category.RequestCategoryDTO;
 import com.meicash.domain.category.ResponseCategoryDTO;
 import com.meicash.service.CategoryService;
 
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -38,4 +39,22 @@ public class CategoryController {
         Optional<ResponseCategoryDTO> category = categoryService.getCategoryById(categoryId);
         return category.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
     }
+
+    @PutMapping("/{categoryId}")
+    public ResponseEntity<ResponseCategoryDTO> updateCategory(@PathVariable String categoryId, @RequestBody @Valid RequestCategoryDTO requestCategoryDTO) {
+        Optional<ResponseCategoryDTO> updatedCategory = categoryService.updateCategory(categoryId, requestCategoryDTO);
+        if (updatedCategory.isPresent()) {
+            return ResponseEntity.ok(updatedCategory.get());
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @DeleteMapping("/{categoryId}")
+    public ResponseEntity<Void> deleteCategory(@PathVariable String categoryId) {
+        return categoryService.deleteCategory(categoryId)
+                ? ResponseEntity.noContent().build()
+                : ResponseEntity.notFound().build();
+    }
+
 }

--- a/src/main/java/com/meicash/service/CategoryService.java
+++ b/src/main/java/com/meicash/service/CategoryService.java
@@ -47,4 +47,24 @@ public class CategoryService {
         }
     }
 
+    public Optional<ResponseCategoryDTO> updateCategory(String categoryId, RequestCategoryDTO requestCategoryDTO) {
+        return categoryRepository.findById(categoryId).map(
+                category -> {
+                    category.setName(requestCategoryDTO.name());
+                    category.setDescription(requestCategoryDTO.description());
+                    return categoryToResponseCategoryDTO(categoryRepository.save(category));
+                }
+        );
+    }
+
+    public boolean deleteCategory(String categoryId) {
+        return categoryRepository.findById(categoryId)
+                .map(category -> {
+                    categoryRepository.delete(category);
+                    return true;
+                })
+                .orElse(false);
+    }
+
+
 }


### PR DESCRIPTION
## Proposta deste PR
- Assim como especificado
  na Issue #27 , é preciso implementar rotas para atualizar e deletar a entidade Category para que a API forneça as rotas necessárias para a manipulação dos dados das categorias.

## Impactos deste PR
- desenvolver as rotas de atualizar categoria e deletar categoria

## Evidências de teste
### Atualização de uma Categoria
![image](https://github.com/JonasFortes12/MEICash-server/assets/107064977/e4554a11-0a28-4e4b-b6b4-ac33f26a48cf)
![image](https://github.com/JonasFortes12/MEICash-server/assets/107064977/9abc4f03-1300-47b8-81ff-bc252f940174)
![image](https://github.com/JonasFortes12/MEICash-server/assets/107064977/dcdcd4d2-e531-4f21-9ed8-1097881eba5e)
### Deletar uma Categoria
![image](https://github.com/JonasFortes12/MEICash-server/assets/107064977/1c9782e9-f656-474d-b687-c6719017919f)
![image](https://github.com/JonasFortes12/MEICash-server/assets/107064977/6ce8726b-e2e7-4cbc-9520-556245fe916a)
