### PR TITLE
Feat/finish category user crud

### DIFF
--- a/src/main/java/com/meicash/controller/ProfileController.java
+++ b/src/main/java/com/meicash/controller/ProfileController.java
@@ -96,6 +96,7 @@ public class ProfileController {
             @ApiResponse(responseCode = "200", description = "Categoria do usuário atualizada com sucesso"),
             @ApiResponse(responseCode = "400", description = "Categoria não encontrada"),
     })
+    @PutMapping("/categories/{categoryId}")
     public ResponseEntity<ResponseCategoryDTO> updateUserCategory(
             @PathVariable final String categoryId,
             @Valid @RequestBody final RequestCategoryDTO requestCategoryDTO
@@ -109,6 +110,27 @@ public class ProfileController {
         ResponseCategoryDTO updatedCategory = profileService.updateUserCategory(categoryToUpdate.get(), requestCategoryDTO);
 
         return ResponseEntity.ok(updatedCategory);
+    }
+
+
+    @Operation(summary = "O usuário deleta uma categoria", description = "Deleta uma categoria do usuário no sistema")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Categoria do usuário deletada com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Categoria não encontrada")
+    })
+    @DeleteMapping("/categories/{categoryId}")
+    public ResponseEntity<Void> deleteUserCategory(@PathVariable final String categoryId) {
+        Optional<Category> categoryToDelete = categoryService.getEntityCategoryById(categoryId);
+
+        if(categoryToDelete.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        if (!profileService.deleteUserCategory(categoryToDelete.get())) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
+        return ResponseEntity.noContent().build();
     }
 
 

--- a/src/main/java/com/meicash/controller/ProfileController.java
+++ b/src/main/java/com/meicash/controller/ProfileController.java
@@ -90,6 +90,28 @@ public class ProfileController {
         return profileService.getUserCategories();
     }
 
+
+    @Operation(summary = "O usuário atualiza uma categoria", description = "Atualiza uma categoria do usuário no sistema")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Categoria do usuário atualizada com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Categoria não encontrada"),
+    })
+    public ResponseEntity<ResponseCategoryDTO> updateUserCategory(
+            @PathVariable final String categoryId,
+            @Valid @RequestBody final RequestCategoryDTO requestCategoryDTO
+    ) {
+        Optional<Category> categoryToUpdate = categoryService.getEntityCategoryById(categoryId);
+
+        if(categoryToUpdate.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        ResponseCategoryDTO updatedCategory = profileService.updateUserCategory(categoryToUpdate.get(), requestCategoryDTO);
+
+        return ResponseEntity.ok(updatedCategory);
+    }
+
+
     @Operation(summary = "O usuário recupera as informações do seu perfil", description = "Recupera o perfil do usuário no sistema")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Perfil do usuário recuperado com sucesso"),

--- a/src/main/java/com/meicash/service/ProfileService.java
+++ b/src/main/java/com/meicash/service/ProfileService.java
@@ -99,6 +99,15 @@ public class ProfileService {
         return categoryToResponseCategoryDTO(categoryRepository.save(category));
     }
 
+    public boolean deleteUserCategory(Category categoryToDelete) {
+        try {
+            categoryRepository.delete(categoryToDelete);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     public ResponseUserDTO getUserProfile() {
         return userToResponseUserDTO(authorizationService.getAuthenticatedUser());
     }

--- a/src/main/java/com/meicash/service/ProfileService.java
+++ b/src/main/java/com/meicash/service/ProfileService.java
@@ -93,6 +93,12 @@ public class ProfileService {
                 .collect(Collectors.toList());
     }
 
+    public ResponseCategoryDTO updateUserCategory(Category category, RequestCategoryDTO requestCategoryDTO) {
+        category.setName(requestCategoryDTO.name());
+        category.setColor(requestCategoryDTO.color());
+        return categoryToResponseCategoryDTO(categoryRepository.save(category));
+    }
+
     public ResponseUserDTO getUserProfile() {
         return userToResponseUserDTO(authorizationService.getAuthenticatedUser());
     }


### PR DESCRIPTION

## Proposta deste PR
- Assim como especificadona Issue #50  , é preciso finalizar as rotas para o usuário manter suas categorias, atualizando-as e deletando-as.

## Impactos deste PR
- Adiciona a rota `PUT` -` profile/categories/{id_category}`
- Adiciona a rota `DELETE` -` profile/categories/{id_category}`

## Evidências de teste
![image](https://github.com/JonasFortes12/MEICash-server/assets/43821439/c06af89a-0fdb-44ed-bcf4-77ea736c7ac6)
![image](https://github.com/JonasFortes12/MEICash-server/assets/43821439/11691035-22c2-464d-8ab8-0501e09dfaeb)
