### PR TITLE
Feat/finish transaction user crud

### DIFF
--- a/src/main/java/com/meicash/controller/ProfileController.java
+++ b/src/main/java/com/meicash/controller/ProfileController.java
@@ -85,6 +85,18 @@ public class ProfileController {
         }
     }
 
+    @Operation(summary = "O usuário deleta uma transação", description = "Deleta uma transação do usuário no sistema")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Transação do usuário deletada com sucesso")
+    })
+    @DeleteMapping("/transactions/{transactionId}")
+    public ResponseEntity<Void> deleteUserTransaction(@PathVariable final String transactionId) {
+        if (!profileService.deleteUserTransaction(transactionId)) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+        return ResponseEntity.noContent().build();
+    }
+
 
     @Operation(summary = "O usuário registra uma nova categoria", description = "Cria uma nova categoria no sistema")
     @ApiResponses(value = {

--- a/src/main/java/com/meicash/controller/ProfileController.java
+++ b/src/main/java/com/meicash/controller/ProfileController.java
@@ -96,6 +96,7 @@ public class ProfileController {
             @ApiResponse(responseCode = "200", description = "Categoria do usuário atualizada com sucesso"),
             @ApiResponse(responseCode = "400", description = "Categoria não encontrada"),
     })
+    @PutMapping("/categories/{categoryId}")
     public ResponseEntity<ResponseCategoryDTO> updateUserCategory(
             @PathVariable final String categoryId,
             @Valid @RequestBody final RequestCategoryDTO requestCategoryDTO
@@ -109,6 +110,27 @@ public class ProfileController {
         ResponseCategoryDTO updatedCategory = profileService.updateUserCategory(categoryToUpdate.get(), requestCategoryDTO);
 
         return ResponseEntity.ok(updatedCategory);
+    }
+
+
+    @Operation(summary = "O usuário deleta uma categoria", description = "Deleta uma categoria do usuário no sistema")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Categoria do usuário deletada com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Categoria não encontrada")
+    })
+    @DeleteMapping("/categories/{categoryId}")
+    public ResponseEntity<Void> deleteUserCategory(@PathVariable final String categoryId) {
+        Optional<Category> categoryToDelete = categoryService.getEntityCategoryById(categoryId);
+
+        if(categoryToDelete.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        if (!profileService.deleteUserCategory(categoryToDelete.get())) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
+        return ResponseEntity.noContent().build();
     }
 
 

--- a/src/main/java/com/meicash/controller/ProfileController.java
+++ b/src/main/java/com/meicash/controller/ProfileController.java
@@ -67,6 +67,25 @@ public class ProfileController {
         return profileService.getUserTransactions();
     }
 
+    @Operation(summary = "O usuário atualiza uma transação", description = "Atualiza uma transação do usuário no sistema")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Transação do usuário atualizada com sucesso"),
+            @ApiResponse(responseCode = "404", description = "Transação não encontrada")
+    })
+    @PutMapping("/transactions/{transactionId}")
+    public ResponseEntity<ResponseTransactionDTO> updateUserTransaction(
+            @PathVariable final String transactionId,
+            @Valid @RequestBody final RequestTransactionDTO requestTransactionDTO
+    ) {
+        Optional<ResponseTransactionDTO> updatedTransaction = profileService.updateUserTransaction(transactionId, requestTransactionDTO);
+        if (updatedTransaction.isPresent()) {
+            return ResponseEntity.ok(updatedTransaction.get());
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+
     @Operation(summary = "O usuário registra uma nova categoria", description = "Cria uma nova categoria no sistema")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Usuário criou categoria com sucesso"),

--- a/src/main/java/com/meicash/controller/ProfileController.java
+++ b/src/main/java/com/meicash/controller/ProfileController.java
@@ -90,6 +90,28 @@ public class ProfileController {
         return profileService.getUserCategories();
     }
 
+
+    @Operation(summary = "O usuário atualiza uma categoria", description = "Atualiza uma categoria do usuário no sistema")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Categoria do usuário atualizada com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Categoria não encontrada"),
+    })
+    public ResponseEntity<ResponseCategoryDTO> updateUserCategory(
+            @PathVariable final String categoryId,
+            @Valid @RequestBody final RequestCategoryDTO requestCategoryDTO
+    ) {
+        Optional<Category> categoryToUpdate = categoryService.getEntityCategoryById(categoryId);
+
+        if(categoryToUpdate.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        ResponseCategoryDTO updatedCategory = profileService.updateUserCategory(categoryToUpdate.get(), requestCategoryDTO);
+
+        return ResponseEntity.ok(updatedCategory);
+    }
+
+
     @Operation(summary = "O usuário recupera as informações do seu perfil", description = "Recupera o perfil do usuário no sistema")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Perfil do usuário recuperado com sucesso"),

--- a/src/main/java/com/meicash/service/ProfileService.java
+++ b/src/main/java/com/meicash/service/ProfileService.java
@@ -99,6 +99,15 @@ public class ProfileService {
         return categoryToResponseCategoryDTO(categoryRepository.save(category));
     }
 
+    public boolean deleteUserCategory(Category categoryToDelete) {
+        try {
+            categoryRepository.delete(categoryToDelete);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     public ResponseUserDTO getUserProfile() {
         return userToResponseUserDTO(authorizationService.getAuthenticatedUser());
     }

--- a/src/main/java/com/meicash/service/ProfileService.java
+++ b/src/main/java/com/meicash/service/ProfileService.java
@@ -93,6 +93,12 @@ public class ProfileService {
                 .collect(Collectors.toList());
     }
 
+    public ResponseCategoryDTO updateUserCategory(Category category, RequestCategoryDTO requestCategoryDTO) {
+        category.setName(requestCategoryDTO.name());
+        category.setColor(requestCategoryDTO.color());
+        return categoryToResponseCategoryDTO(categoryRepository.save(category));
+    }
+
     public ResponseUserDTO getUserProfile() {
         return userToResponseUserDTO(authorizationService.getAuthenticatedUser());
     }

--- a/src/main/java/com/meicash/service/ProfileService.java
+++ b/src/main/java/com/meicash/service/ProfileService.java
@@ -92,6 +92,15 @@ public class ProfileService {
         );
     }
 
+    public  boolean deleteUserTransaction(String transactionId) {
+        return transactionRepository.findById(transactionId)
+                .map(transaction -> {
+                    transactionRepository.delete(transaction);
+                    return true;
+                })
+                .orElse(false);
+    }
+
     public ResponseCategoryDTO userCreateCategory(RequestCategoryDTO requestCategoryDTO) {
         Category newCategory = new Category(requestCategoryDTO);
 

--- a/src/main/java/com/meicash/service/ProfileService.java
+++ b/src/main/java/com/meicash/service/ProfileService.java
@@ -13,6 +13,7 @@ import com.meicash.domain.user.User;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -76,6 +77,19 @@ public class ProfileService {
                 .stream()
                 .map(this::transactionToResponseTransactionDTO)
                 .collect(Collectors.toList());
+    }
+
+    public Optional<ResponseTransactionDTO> updateUserTransaction(String transactionId, RequestTransactionDTO requestTransactionDTO) {
+        return transactionRepository.findById(transactionId).map(
+                transaction -> {
+                    transaction.setTitle(requestTransactionDTO.title());
+                    transaction.setTimestamp(requestTransactionDTO.timestamp());
+                    transaction.setType(requestTransactionDTO.type());
+                    transaction.setValue(requestTransactionDTO.value());
+                    transaction.setDescription(requestTransactionDTO.description());
+                    return transactionToResponseTransactionDTO(transactionRepository.save(transaction));
+                }
+        );
     }
 
     public ResponseCategoryDTO userCreateCategory(RequestCategoryDTO requestCategoryDTO) {

--- a/src/main/java/com/meicash/service/TransactionService.java
+++ b/src/main/java/com/meicash/service/TransactionService.java
@@ -58,6 +58,7 @@ public class TransactionService {
     public Optional<ResponseTransactionDTO> updateTransaction(String transactionId, RequestTransactionDTO requestTransactionDTO) {
         return transactionRepository.findById(transactionId).map(
                 transaction -> {
+                    transaction.setTitle(requestTransactionDTO.title());
                     transaction.setTimestamp(requestTransactionDTO.timestamp());
                     transaction.setType(requestTransactionDTO.type());
                     transaction.setValue(requestTransactionDTO.value());


### PR DESCRIPTION

## Proposta deste PR
- Assim como especificadona Issue #51, é preciso finalizar as rotas para o usuário manter suas transações, atualizando-as e deletando-as.

## Impactos deste PR
- Adiciona a rota `PUT` -` profile/transactions/{id_transaction}`
- Adiciona a rota `DELETE` -` profile/transactions/{id_transaction}`

## Evidências de teste
![image](https://github.com/JonasFortes12/MEICash-server/assets/43821439/6d19f0b5-ba04-4f60-b62b-5e674dcf5461)
![image](https://github.com/JonasFortes12/MEICash-server/assets/43821439/b53f9c12-d0ca-46f7-9cbd-98139b8e0c75)
